### PR TITLE
Config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Jump To:
 * [why was this made and what situations is it good for?](#who-for)
 * [usage, helpscreen version](#usage-helpscreen)
 * [javascript api](#jsapi)
+* [config file](#configfile)
 * [getting the source/executable files](#getting-files)
 * [getting started with demos](#getting-started)
 * [who to contact](#todo)
@@ -113,6 +114,7 @@ From `#slfsrv --help`
                  whether it is OK to replace the <output-name> file
       -port <port#> - specify port to run server on, else will look for a random port
                       that is not in use
+      -config-file <json file> - path to json config file name
       -verbose - write out lots of message about what's going on (else silent)
     EXAMPLES:
       slfsrv
@@ -121,6 +123,7 @@ From `#slfsrv --help`
       slfsrv -compile /myapp
       slfsrv -compile /myapp -compile-from /tools/ss/win/slfsrv.exe
       slfsrv c:\user\me photo/tools/photoview.html
+      slfsrv c:\user\me photo/tools/photoview.html -config-file ./config.json
     VERSION: 0.0.1
 
 ------------------------------------------------------------------------------
@@ -128,6 +131,22 @@ From `#slfsrv --help`
 ### JavaScript API:
 
 [&#x25BA; Javascript API](docs/JSAPI.md) - calls made available to javascript running in the browser
+
+------------------------------------------------------------------------------
+<a name="configfile"></a>
+### Configuration file
+
+If you supply a configuration file, it should be json with the following optional fields:
+
+keepAliveSeconds: (int64) number of seconds to wait for a keepalive message before quitting.
+Supply a large number to allow the app to stay alive even if page is pinging the server.
+
+secretKey: (string) client has this key for rudimentary security. If none supplied, the app
+will generate one.
+
+port: (int) port to run server on.  If none supplied it will find an available port.
+Note that the port can also be supplied on the command line.
+
 
 ------------------------------------------------------------------------------
 <a name="getting-files"></a>

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/BrentNoorda/slfsrv/ssutil"
+	"io/ioutil"
+	"strings"
+)
+
+type PathDescription struct {
+	FsPath      []string
+	WebPath     []string
+	Description string
+	IsRelative  bool
+}
+
+type Settings struct {
+	SecretKey        string
+	Port             int
+	KeepAliveSeconds int64
+	SecretKeyInPath  bool
+}
+
+var webRoutes []PathDescription
+var settings Settings
+
+// call once to initialize
+func ParseConfigFile(filename string) {
+
+	type PathDescriptionJson struct {
+		FsPath      string `json:"fsPath"`
+		WebPath     string `json:"webPath"`
+		Description string `json:"description"`
+		Security    int    `json:"security"`
+	}
+
+	type ConfigJson struct {
+		Routing          []PathDescriptionJson `json:"routing"`
+		Port             int                   `json:"port"`
+		KeepAliveSeconds int64                 `json:"keepAliveSeconds"`
+		SecretKey        string                `json:"secretKey"`
+		SecretKeyInPath  bool                  `json:"secretKeyInPath"`
+	}
+
+	if filename == "" {
+		filename = "./config.json"
+	}
+
+	content, err := ioutil.ReadFile(filename)
+	if err == nil {
+		var tmpConfig ConfigJson
+		err := json.Unmarshal(content, &tmpConfig)
+		if err != nil {
+			fmt.Println(err)
+		}
+		settings.Port = tmpConfig.Port
+		settings.KeepAliveSeconds = tmpConfig.KeepAliveSeconds
+		settings.SecretKey = tmpConfig.SecretKey
+		settings.SecretKeyInPath = tmpConfig.SecretKeyInPath
+
+		webRoutes = make([]PathDescription, len(tmpConfig.Routing))
+
+		for i := 0; i < len(tmpConfig.Routing); i++ {
+			item := tmpConfig.Routing[i]
+			webRoutes[i].FsPath, webRoutes[i].IsRelative = ssutil.PathStringToArray(item.FsPath)
+			webRoutes[i].WebPath, _ = ssutil.PathStringToArray(item.WebPath)
+			webRoutes[i].Description = item.Description
+		}
+		// fmt.Printf("webRoutes: %+v\n\n", webRoutes)
+		// fmt.Printf("settings: %+v\n\n", settings)
+	}
+}
+
+func GetSettings() *Settings {
+	return &settings
+}
+
+// call when we have a web request.  Gets an array of all possible
+// file system paths that could satisfy the request. This allows multiple
+// file system directories to handle a single web directory....it will
+// just serve the first file (ordered based on the config file) that
+// is valid for that url
+func GetPossibleFilePathsFromUrl(url string) []string {
+	out := make([]string, 0, 3)
+
+	urlPath, _ := ssutil.PathStringToArray(url)
+
+	for i := 0; i < len(webRoutes); i++ {
+		success := true
+		webPath := webRoutes[i].WebPath
+		lenWebPath := len(webPath)
+		for j := 0; j < lenWebPath; j++ {
+			if j >= len(urlPath) {
+				break
+			}
+			if webPath[j] != urlPath[j] {
+				success = false
+				break
+			}
+		}
+		if success {
+			if lenWebPath <= len(urlPath) {
+				startPath := "/"
+				if webRoutes[i].IsRelative {
+					startPath = ""
+				}
+				out = append(out, startPath+
+					strings.Join(webRoutes[i].FsPath, "/")+"/"+
+					strings.Join(urlPath[lenWebPath:], "/"))
+			}
+		}
+	}
+	return out
+}

--- a/slfsrv.go
+++ b/slfsrv.go
@@ -313,7 +313,7 @@ func main() {
 		if settings.KeepAliveSeconds != 0 {
 			keepAliveSeconds = settings.KeepAliveSeconds
 		} else {
-			settings.KeepAliveSeconds = 2
+			keepAliveSeconds = 2
 		}
 
 		port = webserver.ListenAndServe(port, secretKey, keepAliveSeconds, zipReader, patharg, fullpatharg, initPathUrl,

--- a/ssutil/ssutil.go
+++ b/ssutil/ssutil.go
@@ -70,3 +70,16 @@ func CleanPathRelativeToCwd(pathspec string, cwd string) string {
 	}
 	return pathspec
 }
+
+// note:  we could use os.PathSeparator, but this means that the
+// config file must be platform dependent
+func PathStringToArray(pathStr string) ([]string, bool) {
+	isRel := strings.Index(pathStr, "/") != 0
+	trimmed := strings.Trim(pathStr, "/")
+
+	out := strings.Split(trimmed, "/")
+	if len(out) == 1 && len(out[0]) == 0 {
+		return out[0:0], isRel
+	}
+	return out, isRel
+}

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -216,10 +216,10 @@ func web_server_forever(secretKey string, wsData *webserverData,
 	os.Exit(1)
 }
 
-func keep_aliver(keepAliveChan chan int, exitChan chan int, verbose bool) {
+func keep_aliver(keepAliveChan chan int, exitChan chan int, verbose bool, keepAliveSeconds int64) {
 	// quit if not tickled within a few seconds
 
-	var maxwait time.Duration = time.Second * 10 // first call can take longer than others
+	maxwait := time.Second * time.Duration(keepAliveSeconds)
 	for {
 		select {
 		case <-keepAliveChan:
@@ -229,11 +229,10 @@ func keep_aliver(keepAliveChan chan int, exitChan chan int, verbose bool) {
 			}
 			exitChan <- 1
 		}
-		maxwait = time.Second * 2
 	}
 }
 
-func ListenAndServe(port int, secretKey string, zipReader *zip.Reader,
+func ListenAndServe(port int, secretKey string, keepAliveSeconds int64, zipReader *zip.Reader,
 	rootPath string, fullRootPath string, initFile string,
 	verbose bool, exitChan chan int, myselfExecutable string,
 	storeFilespec string) int {
@@ -262,7 +261,7 @@ func ListenAndServe(port int, secretKey string, zipReader *zip.Reader,
 		zipReader: zipReader}
 	go web_server_forever(secretKey, &wsData, port, rootPath, myselfExecutable)
 
-	go keep_aliver(keepAliveChan, exitChan, verbose)
+	go keep_aliver(keepAliveChan, exitChan, verbose, keepAliveSeconds)
 
 	return port
 }


### PR DESCRIPTION
Note that this includes routing stuff but it is not used.  Currently this has three config settings variables that are used: secretKey, port, and keepAliveSeconds.  Config file can be specified on the command line, or if there is a config.json in the current directory, it will use that.  If no config file is specified or found, behavior should be as before.
